### PR TITLE
feat: limit on lottery

### DIFF
--- a/src/lottery.rs
+++ b/src/lottery.rs
@@ -24,6 +24,7 @@ pub async fn cached_lottery_winners(
     boost_info: &BoostInfo,
     proposal_info: &ProposalInfo,
     num_winners: u32,
+    limit: Option<u16>,
 ) -> Result<HashMap<Address, U256>, ServerError> {
     let variables = every_vote_query::Variables {
         proposal: proposal_info.id.to_owned(),
@@ -60,16 +61,79 @@ pub async fn cached_lottery_winners(
         votes.retain(|v| v.choice == boosted_choice);
     }
 
-    let prize = boost_info.pool_size / num_winners;
-    let seed = ChaCha20Rng::from_entropy().gen(); // todo: e.g from block ranDAO reveal
-
     // Every voter is eligible to the same reward!
     if votes.len() <= num_winners as usize {
         let prize = boost_info.pool_size / votes.len() as u32;
         return Ok(votes.into_iter().map(|v| (v.voter, prize)).collect());
     }
 
+    if let Some(limit) = limit {
+        adjust_vote_weights(&mut votes, boost_info.decimals, proposal_info.score, limit)?;
+    }
+
+    let prize = boost_info.pool_size / num_winners;
+    let seed = ChaCha20Rng::from_entropy().gen(); // todo: e.g from block ranDAO reveal
+
     Ok(draw_winners(votes, seed, num_winners, prize))
+}
+
+// Adjust the voting power of the voters to respect the limit.
+// The limit is given in base `10_000`, meaning a limit of `1000` means "no one should have more than 10% chances of getting picked".
+// To enforce that, we iterate through the voters' voting power and adjust their voting power to respect the limit.
+// If there are not enough voters to reach the limit, the limit will be ignored (e.g: if the limit is 1%, and there is only one voter,
+// the voter will get 100% of the prize). Limit will be ignored if set to 0.
+// The array of `votes` is assumed to be sorted by voting power.
+fn adjust_vote_weights(
+    votes: &mut [VoteInfo],
+    decimals: u8,
+    score: f64,
+    limit: u16,
+) -> Result<(), ServerError> {
+    // Ensure the vector is sorted
+    if votes
+        .windows(2)
+        .any(|w| w[0].voting_power < w[1].voting_power)
+    {
+        return Err(ServerError::ErrorString("votes are not sorted".to_string()));
+    }
+
+    if limit == 0 {
+        // log needed
+        return Ok(());
+    }
+
+    if votes.len() < (10_000.0 / limit as f64).ceil() as usize {
+        // log needed "not enough voters to enforce the limit"
+        return Ok(());
+    }
+
+    let pow = 10_f64.powi(decimals as i32);
+
+    // The "voting power" remaining. At each iteration, we will subtract the voting power of the voter.
+    let mut remaining_score = U256::from((score * pow) as u128);
+
+    // The "adjust voting power" remaining. At each iteration, we will subtract the adjusted voting power of the voter.
+    let mut adjusted_remaining_score = remaining_score;
+
+    // The maximum adjusted voting power that can be assigned to any voter
+    let vp_limit = remaining_score * limit / 10_000; // TODO: constant
+
+    votes.iter_mut().for_each(|v| {
+        let vp = U256::from((v.voting_power * pow) as u128);
+        // If the user reaches the limit, assign the limit, else assign the correct ratio.
+        let adjusted_voting_power =
+            std::cmp::min(vp_limit, adjusted_remaining_score * vp / remaining_score);
+
+        // Subtract the voting power
+        remaining_score -= vp;
+        // Subtract the adjusted voting power
+        adjusted_remaining_score -= adjusted_voting_power;
+
+        // Update the voter's voting power
+        v.voting_power = adjusted_voting_power.as_u128() as f64 / pow;
+    });
+
+    Ok(())
 }
 
 fn draw_winners(
@@ -201,5 +265,185 @@ mod test_draw_winners {
         let _ = draw_winners(votes, rng.gen(), 1000, prize);
         let finish = std::time::Instant::now();
         println!("Time: {:?}", finish - start);
+    }
+}
+
+#[cfg(test)]
+mod test_adjust_vote_weights {
+    use super::adjust_vote_weights;
+    use super::VoteInfo;
+
+    #[test]
+    fn test_adjust_vote_weights_half() {
+        let mut votes = vec![
+            VoteInfo {
+                voting_power: 900.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 100.0,
+                ..Default::default()
+            },
+        ];
+        let decimals = 18;
+        let score = votes.iter().map(|v| v.voting_power).sum::<f64>();
+        let limit = 5000; // 50 %
+
+        adjust_vote_weights(&mut votes, decimals, score, limit).unwrap();
+
+        assert_eq!(votes[0].voting_power, 500.0);
+        assert_eq!(votes[1].voting_power, 500.0);
+    }
+
+    #[test]
+    fn test_adjust_no_op() {
+        let mut votes = vec![
+            VoteInfo {
+                voting_power: 900.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 100.0,
+                ..Default::default()
+            },
+        ];
+        let decimals = 18;
+        let score = votes.iter().map(|v| v.voting_power).sum::<f64>();
+        let limit = 100; // 1 %
+
+        adjust_vote_weights(&mut votes, decimals, score, limit).unwrap();
+
+        assert_eq!(votes[0].voting_power, 900.0);
+        assert_eq!(votes[1].voting_power, 100.0);
+    }
+
+    #[test]
+    fn test_adjust_limit_zero() {
+        let mut votes = vec![
+            VoteInfo {
+                voting_power: 900.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 100.0,
+                ..Default::default()
+            },
+        ];
+        let decimals = 18;
+        let score = votes.iter().map(|v| v.voting_power).sum::<f64>();
+        let limit = 0; // 0 %
+
+        adjust_vote_weights(&mut votes, decimals, score, limit).unwrap();
+
+        assert_eq!(votes[0].voting_power, 900.0);
+        assert_eq!(votes[1].voting_power, 100.0);
+    }
+
+    #[test]
+    fn test_adjust_limit_no_op_rounded() {
+        let mut votes = vec![
+            VoteInfo {
+                voting_power: 900.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 50.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 50.0,
+                ..Default::default()
+            },
+        ];
+        let decimals = 18;
+        let score = votes.iter().map(|v| v.voting_power).sum::<f64>();
+        let limit = 3000; // 30 %
+
+        // Would need 4 voters but we only have three so no-op
+        adjust_vote_weights(&mut votes, decimals, score, limit).unwrap();
+
+        assert_eq!(votes[0].voting_power, 900.0);
+        assert_eq!(votes[1].voting_power, 50.0);
+        assert_eq!(votes[2].voting_power, 50.0);
+    }
+
+    #[test]
+    fn test_adjust_limit_rounded() {
+        let mut votes = vec![
+            VoteInfo {
+                voting_power: 800.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 100.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 50.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 50.0,
+                ..Default::default()
+            },
+        ];
+        let decimals = 18;
+        let score = votes.iter().map(|v| v.voting_power).sum::<f64>();
+        let limit = 3000; // 30 %
+
+        // We indeed have 4 voters, votes should get adjusted
+        adjust_vote_weights(&mut votes, decimals, score, limit).unwrap();
+
+        assert_eq!(votes[0].voting_power, 300.0);
+        assert_eq!(votes[1].voting_power, 300.0);
+        assert_eq!(votes[2].voting_power, 200.0);
+        assert_eq!(votes[2].voting_power, 200.0);
+    }
+
+    #[test]
+    fn test_adjust_vote_weights() {
+        let mut votes = vec![
+            VoteInfo {
+                voting_power: 458.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 200.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 180.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 150.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 5.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 4.0,
+                ..Default::default()
+            },
+            VoteInfo {
+                voting_power: 3.0,
+                ..Default::default()
+            },
+        ];
+        let decimals = 18;
+        let score = votes.iter().map(|v| v.voting_power).sum::<f64>();
+        let limit = 2000; // 20 %
+
+        adjust_vote_weights(&mut votes, decimals, score, limit).unwrap();
+
+        assert_eq!(votes[0].voting_power, 200.0);
+        assert_eq!(votes[1].voting_power, 200.0);
+        assert_eq!(votes[2].voting_power, 200.0);
+        assert_eq!(votes[3].voting_power, 200.0);
+        assert_eq!(votes[4].voting_power, 83.33333333333333);
+        assert_eq!(votes[5].voting_power, 66.66666666666666);
+        assert_eq!(votes[6].voting_power, 50.0);
     }
 }


### PR DESCRIPTION
Adds the `limit` functionality on the `lottery` distribution type.

Basically, this allows the user to specify the "maximum percentage of chances for a voter to get elected" (anti-whale measure). E.g: One sets the limit to `10%` : no individual voter will have more than `10%` chances of getting picked.

The implementation enforces that by adjusting the voter's voting power prior to running the lottery. The `limit` is expected to be given not as a percentage but as a per-myriad (`10,000`), allowing users to set any number between `0.01% - 100%`. in the UI.

The `limit` is not enforced if:
- limit is set to `0`
- there are not enough voters (e.g there's a single voter and the limit is `50%`. The voter will get 100% chances of getting picked)