### PR TITLE
Feat support winning choice

### DIFF
--- a/src/lottery.rs
+++ b/src/lottery.rs
@@ -31,7 +31,7 @@ pub async fn cached_lottery_winners(
     num_winners: u32,
     limit: Option<u16>,
 ) -> Result<HashMap<Address, U256>, ServerError> {
-    let bribed_choice = proposal_info.get_bribed_choice(&boost_info.params.eligibility);
+    let bribed_choice = proposal_info.get_bribed_choice(&boost_info.params.eligibility)?;
 
     let choice_constraint = if let Some(choice) = bribed_choice {
         format!("AND choice = {}", choice)

--- a/src/lottery.rs
+++ b/src/lottery.rs
@@ -31,12 +31,13 @@ pub async fn cached_lottery_winners(
     num_winners: u32,
     limit: Option<u16>,
 ) -> Result<HashMap<Address, U256>, ServerError> {
-    let choice_constraint =
-        if let Some(boosted_choice) = boost_info.params.eligibility.boosted_choice() {
-            format!("AND choice = {}", boosted_choice)
-        } else {
-            "".to_string()
-        };
+    let bribed_choice = proposal_info.get_bribed_choice(&boost_info.params.eligibility);
+
+    let choice_constraint = if let Some(choice) = bribed_choice {
+        format!("AND choice = {}", choice)
+    } else {
+        "".to_string()
+    };
 
     let query = format!(
         "SELECT voter, vp, choice


### PR DESCRIPTION
Adds support to bribe the "winning" choice.
Uses `0` as the `BribeWinningChoice` value. Indeed, since choice are `1-indexed`, it shouldn't be cause any issue.

This might come in handy for DAOs that want to incentivise people to vote on what they *think* the outcome will be.
Coupled with a support for Shutter-privacy proposals, this opens up new interesting opportunities.

The quorum does not need to be reached for users to still be able to claim.

Closes #87 