### PR TITLE
fix: Update subgraph URLs to published subgraphs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 name: CI
 env:
   PRIVATE_KEY: "0xafdfd9c3d2095ef696594f6cedcae59e72dcd697e2a7521b1578140422a4f890" # This is a test private key
-  MAINNET_SUBGRAPH_URL: "https://api.studio.thegraph.com/query/23545/boost/version/latest"
-  SEPOLIA_SUBGRAPH_URL: "https://api.studio.thegraph.com/query/23545/boost-sepolia/version/latest"
-  POLYGON_SUBGRAPH_URL: "https://api.studio.thegraph.com/query/23545/boost-polygon/version/latest"
-  BASE_SUBGRAPH_URL: "https://api.studio.thegraph.com/query/23545/boost-base/version/latest"
+  MAINNET_SUBGRAPH_URL: "https://subgrapher.snapshot.org/subgraph/arbitrum/A6EEuSAB7mFrWvLBnL1HZXwfiGfqFYnFJjc14REtMNkd"
+  SEPOLIA_SUBGRAPH_URL: "https://subgrapher.snapshot.org/subgraph/arbitrum/6T64qrPe7S46zhArSoBF8CAmc5cG3PyKa92Nt4Jhymcy"
+  POLYGON_SUBGRAPH_URL: "https://subgrapher.snapshot.org/subgraph/arbitrum/CkNpf5gY7XPCinJWP1nh8K7u6faXwDjchGGV4P9rgJ7"
+  BASE_SUBGRAPH_URL: "https://subgrapher.snapshot.org/subgraph/arbitrum/52uVpyUHkkMFieRk1khbdshUw26CNHWAEuqLojZzcyjd"
   BOOST_NAME: "boost"
   BOOST_VERSION: "0.1.0"
   VERIFYING_CONTRACT: "0x8E8913197114c911F13cfBfCBBD138C1DC74B964"

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ RUN apt-get update && apt-get install -y ca-certificates libssl-dev libssl3
 WORKDIR /app
 COPY --from=builder /app/target/release/boost-guard /usr/local/bin
 
-ENV SEPOLIA_SUBGRAPH_URL "https://api.studio.thegraph.com/query/23545/boost-sepolia/version/latest"
-ENV MAINNET_SUBGRAPH_URL "https://api.studio.thegraph.com/query/23545/boost/version/latest"
-ENV POLYGON_SUBGRAPH_URL "https://api.studio.thegraph.com/query/23545/boost-polygon/version/latest"
-ENV BASE_SUBGRAPH_URL "https://api.studio.thegraph.com/query/23545/boost-base/version/latest"
+ENV SEPOLIA_SUBGRAPH_URL "https://subgrapher.snapshot.org/subgraph/arbitrum/6T64qrPe7S46zhArSoBF8CAmc5cG3PyKa92Nt4Jhymcy"
+ENV MAINNET_SUBGRAPH_URL "https://subgrapher.snapshot.org/subgraph/arbitrum/A6EEuSAB7mFrWvLBnL1HZXwfiGfqFYnFJjc14REtMNkd"
+ENV POLYGON_SUBGRAPH_URL "https://subgrapher.snapshot.org/subgraph/arbitrum/CkNpf5gY7XPCinJWP1nh8K7u6faXwDjchGGV4P9rgJ7"
+ENV BASE_SUBGRAPH_URL "https://subgrapher.snapshot.org/subgraph/arbitrum/52uVpyUHkkMFieRk1khbdshUw26CNHWAEuqLojZzcyjd"
 ENV BOOST_NAME "boost"
 ENV BOOST_VERSION "0.1.0"
 ENV VERIFYING_CONTRACT "0x8E8913197114c911F13cfBfCBBD138C1DC74B964"


### PR DESCRIPTION
### Summary
Related to https://github.com/snapshot-labs/pitches/issues/84

Use published subgraphs
- https://thegraph.com/explorer/subgraphs/A6EEuSAB7mFrWvLBnL1HZXwfiGfqFYnFJjc14REtMNkd?view=Query&chain=arbitrum-one
- https://thegraph.com/explorer/subgraphs/6T64qrPe7S46zhArSoBF8CAmc5cG3PyKa92Nt4Jhymcy?view=Query&chain=arbitrum-one
- https://thegraph.com/explorer/subgraphs/CkNpf5gY7XPCinJWP1nh8K7u6faXwDjchGGV4P9rgJ7?view=Query&chain=arbitrum-one
- https://thegraph.com/explorer/subgraphs/52uVpyUHkkMFieRk1khbdshUw26CNHWAEuqLojZzcyjd?view=Query&chain=arbitrum-one
